### PR TITLE
When headline is set, set title text

### DIFF
--- a/libbirdfont/Expander.vala
+++ b/libbirdfont/Expander.vala
@@ -53,7 +53,7 @@ public class Expander : GLib.Object {
 		title = new Text ();
 
 		if (headline != null) {
-			title.set_text ((!) headline);
+			set_headline(headline);
 		}
 				
 		tool = new Gee.ArrayList<Tool> ();
@@ -65,6 +65,7 @@ public class Expander : GLib.Object {
 
 	public void set_headline (string? h) {
 		headline = h;
+		title.set_text ((!) headline);
 	}
 
 	public double get_content_height () {


### PR DESCRIPTION
Problem:
When a background tool was selected, the background toolbox would
retain the "Control Points" title even though the tools had changed.

Solution:
Set the title text on an expander when set_headline() is called.

Signed-off-by: David Turner <novalis@novalis.org>