### PR TITLE
Use the right header to get malloc(3)

### DIFF
--- a/libbirdgems/fit_cubic.c
+++ b/libbirdgems/fit_cubic.c
@@ -22,10 +22,10 @@ Adapted to BirdFont by Johan Mattsson 2015
 
 #include "GraphicsGems.h"
 
-#ifdef MAC
-#include <malloc/malloc.h>
-#else
+#ifdef __linux__
 #include <malloc.h>
+#else
+#include <stdlib.h>
 #endif
 
 #include <math.h>


### PR DESCRIPTION
it seems only linux doesn't have `malloc(3)` defined in `stdlib.h`, even though
this is required by POSIX. On OS X `malloc(3)` lives in `stdlib.h`, and only the
special functions such as `malloc_size(3)` are defined in `malloc/malloc.h`.

OpenBSD's `malloc.h` is actually:

```
/*      $OpenBSD: malloc.h,v 1.2 1996/10/12 03:13:56 tholo Exp $        */
/*      $NetBSD: malloc.h,v 1.3 1994/10/26 00:56:03 cgd Exp $   */

#warning "<malloc.h> is obsolete, use <stdlib.h>"

#include <stdlib.h>
```

I haven't tested this diff on Linux/OS X so additional testing is welcome.