### PR TITLE
configure: respect --valac option

### DIFF
--- a/configure
+++ b/configure
@@ -87,10 +87,10 @@ def has_posixvala ():
 		print (OKGREEN + 'Using posix profile.' + ENDC)			
 	return 'True'
 
-def configure(gtk, libbgee):
+def configure(gtk, libbgee, valac):
 	global gee
 	
-	if not test_program_version ('valac', 0, 16, 0):
+	if not test_program_version(valac, 0, 16, 0):
 		print (FAIL + 'valac is too old.' + ENDC)
 		exit (1)
 
@@ -203,7 +203,7 @@ if not options.nonnull:
 else:
 	options.nonnull = True
 	
-configure(options.gtk, options.gee)
+configure(options.gtk, options.gee, options.valac)
 
 configfile.write_config(options.prefix)
 configfile.write_compile_parameters(options.prefix,


### PR DESCRIPTION
Make sure we don't still test `valac` when the compiler has been set to
a specific version/path.