### PR TITLE
Don't recommend obsolete libwebkit2gtk-3.0-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ packages with a -dev or -devel affix:
     libgee-0.8-dev
     libglib2.0-dev 
     libgtk-3-dev 
-    libwebkit2gtk-3.0-dev 
+    libwebkit2gtk-4.0-dev
     libnotify-dev
     libsqlite3-dev
 


### PR DESCRIPTION
libwebkit2gtk-3.0-dev is no longer maintained. Ubuntu 16.04 and Debian 9 "Stretch" offer libwebkit2gtk-4.0-dev which is currently supported.