### PR TITLE
Fix warning: "This font was made with a newer version of Birdfont."

### DIFF
--- a/libbirdfont/BirdFontFile.vala
+++ b/libbirdfont/BirdFontFile.vala
@@ -914,7 +914,7 @@ class BirdFontFile : GLib.Object {
 		}
 		
 		font.format_major = int.parse (v[0]);
-		font.format_major = int.parse (v[1]);
+		font.format_minor = int.parse (v[1]);
 	}
 	
 	public void parse_images (Tag tag) {


### PR DESCRIPTION
There is always a warning "This font was made with a newer version of Birdfont."