### PR TITLE
Birdfont tries to delete configuration directory

### DIFF
--- a/libbirdfont/FontSettings.vala
+++ b/libbirdfont/FontSettings.vala
@@ -24,7 +24,7 @@ public class FontSettings : GLib.Object {
 
 	public FontSettings () {
 		settings = new Gee.HashMap<string, string> ();
-		font_name = "";
+		font_name = "new.bf";
 	}
 	
 	public string get_setting (string key) {


### PR DESCRIPTION
When I create a new font and open any glyph for editing, Birdfont tries to delete the directory ~/.config/birdfont.
Нow to repeat.
Start Birdfont from console.
Press "New font"
Double click on some char.
View console. Appear line "Can not save settings. (Error removing file /home/jack/.config/birdfont: Directory not empty)"
