### PR TITLE
Add gettext to dependency list in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ packages with a -dev or -devel affix:
     libwebkit2gtk-4.1-dev
     libnotify-dev
     libsqlite3-dev
+    gettext
 
 XML Bird is available from [birdfont.org][xmlbird].
 


### PR DESCRIPTION
birdfont/scripts/translations.py executes the msgfmt command, which is provided by gettext